### PR TITLE
Adding -fallow-argument-mismatch for gfortran 11.2

### DIFF
--- a/Compilers/Linux-gfortran.mk
+++ b/Compilers/Linux-gfortran.mk
@@ -33,7 +33,7 @@
 # First the defaults
 #
                FC := gfortran
-           FFLAGS := -frepack-arrays
+           FFLAGS := -frepack-arrays -fallow-argument-mismatch
        FIXEDFLAGS := -ffixed-form
         FREEFLAGS := -ffree-form -ffree-line-length-none
               CPP := /usr/bin/cpp


### PR DESCRIPTION
I attended the ARM Hackathon last week, and when running gfortran 11.2.0, this flag is required to let mismatched arguments be warnings instead of errors.

I'm not sure if this is the best place to put this flag, but it worked for me. 