### PR TITLE
Add links to COAWST Wiki, Trainings, and Publications

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,4 +8,7 @@ Users need to be aware that this is a major update, and requires use of new:
 - makefile
 - Compilers files
 
+# [COAWST Wiki](https://github.com/DOI-USGS/COAWST/wiki)
+- [COAWST Trainings](https://github.com/DOI-USGS/COAWST/wiki/COAWST-Trainings)
+- [Publications](https://github.com/DOI-USGS/COAWST/wiki/Publications)
 


### PR DESCRIPTION
I have added links to wiki in the readme file so that it is readily available from the landing page. 